### PR TITLE
Add 'Amigos e Parceiros' page and navigation link; update routes and home links

### DIFF
--- a/src/components/geral/Nav.astro
+++ b/src/components/geral/Nav.astro
@@ -23,6 +23,15 @@ type Route = {
                 Quem Somos
             </a>
         </li>
+        <li>
+            <a
+                class={`nav-link ${currentPath === '/amigos-e-parceiros' ? 'active' : ''}`}
+                href="/amigos-e-parceiros"
+            >
+                <img src={flor.src} alt="Flor" class="nav-icon" />
+                Amigos e Parceiros
+            </a>
+        </li>
         {
             routes.slice(0, 5).map(({ slug, title }: Route) => (
                 <>

--- a/src/components/home/Link.astro
+++ b/src/components/home/Link.astro
@@ -17,7 +17,7 @@ import flor from '../../images/icon/flor.svg';
     }
 
     .white {
-        @apply pl-8 mt-28 text-white transition hover:text-white/75;
+        @apply pl-8 text-white transition hover:text-white/75;
     }
 
     .black {

--- a/src/components/home/Main.astro
+++ b/src/components/home/Main.astro
@@ -6,7 +6,10 @@ import Link from '../../components/home/Link.astro';
 
 <main class="content">
     <Logo className="home"/>
-    <Link href="/quem-somos" color="white">Quem somos?</Link>
+    <div class="links">
+        <Link href="/quem-somos" color="white">Quem somos?</Link>
+        <Link href="/amigos-e-parceiros" color="white">Amigos e Parceiros</Link>
+    </div>
 </main>
 
 <style>
@@ -14,4 +17,12 @@ import Link from '../../components/home/Link.astro';
         @apply flex flex-col items-start min-h-screen w-full bg-cover;
         background-image: url('/background/background-index-2.png');
     } 
+
+    .links {
+        @apply flex flex-col gap-4;
+    }
+
+    .links :global(a:first-child) {
+        @apply mt-28;
+    }
 </style>

--- a/src/pages/amigos-e-parceiros.astro
+++ b/src/pages/amigos-e-parceiros.astro
@@ -19,7 +19,7 @@ import Gallery from '../components/Gallery.astro';
 const paginaResponse = await getPageQuemSomos();
 const pagina = paginaResponse?.Conteudo ? paginaResponse : { Conteudo: [] };
 
-const tituloPagina = `Quitungo | Quem Somos`;
+const tituloPagina = `Quitungo | Amigos e Parceiros`;
 ---
 
 <Layout title={tituloPagina}>
@@ -28,7 +28,7 @@ const tituloPagina = `Quitungo | Quem Somos`;
         <Section>
             <Card>
                 <CardGridPaginas>
-                    <TitleMain titulo="Quem Somos" />
+                    <TitleMain titulo="Amigos e Parceiros" />
 
                     {
                         pagina.Conteudo.map((item: any) => {

--- a/src/utils/routes.js
+++ b/src/utils/routes.js
@@ -1,5 +1,6 @@
 export const routes = [
   { slug: "quem-somos", title: "Quem Somos", description: "" },
+  { slug: "amigos-e-parceiros", title: "Amigos e Parceiros", description: "" },
   { slug: "trabalhos-academicos", title: "Trabalhos Acadêmicos", description: "Pesquisas e publicações" },
   { slug: "trabalhos-tecnicos", title: "Trabalhos Técnicos", description: "Estudos e projetos realizados" },
   { slug: "cartografias", title: "Cartografias", description: "Mapas e outras representações geográficas" },


### PR DESCRIPTION
### Motivation
- Add a dedicated "Amigos e Parceiros" page and expose it in the site navigation and home links for discoverability.
- Keep route metadata in sync by adding the new slug to the central routes list.
- Ensure page content retrieval is resilient to missing or malformed API responses.
- Adjust link spacing in the home component so layout spacing is applied consistently via the wrapper instead of the link component.

### Description
- Added a new page `src/pages/amigos-e-parceiros.astro` that renders content (using the same `getPageQuemSomos` endpoint) and supports all existing content block types like titles, text, images, media, gallery, video, audio, and documents.
- Updated navigation in `src/components/geral/Nav.astro` to include a static link to `/amigos-e-parceiros` and highlight it when active.
- Updated the home layout in `src/components/home/Main.astro` to include a second link to the new page inside a `.links` wrapper and applied top margin to the first link via `.links :global(a:first-child)`.
- Modified `src/components/home/Link.astro` to remove the direct `mt-28` margin from the `.white` variant so spacing is controlled by parent layout.
- Added the new route entry to `src/utils/routes.js` with `slug: "amigos-e-parceiros"` and `title: "Amigos e Parceiros"`.
- Made API response handling in `src/pages/quem-somos.astro` more robust by checking `paginaResponse?.Conteudo` instead of relying on `.catch`.

### Testing
- Ran a site build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa1c89f73083318266cc936b42236b)